### PR TITLE
Add support for the `GITHUB_NOTIFICATIONS_TOKEN` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ It adds 2 commands to the command palette:
 This extension requires you to provide an OAuth token, to create it go [here](https://github.com/settings/tokens), click "Generate new token" and be sure to select the "notifications" scope, then click "Generate token".
 
 - **Environment variables**: the following environment variables are supported too: `GITHUB_NOTIFICATIONS_TOKEN`.
+  - you can set the environment variable in your shell config file `export GITHUB_NOTIFICATIONS_TOKEN='your_token_here'` or before you start VS Code, if you're starting it from terminal: `GITHUB_NOTIFICATIONS_TOKEN='your_token_here' code`
 
 
 ```js

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ It adds 2 commands to the command palette:
 
 This extension requires you to provide an OAuth token, to create it go [here](https://github.com/settings/tokens), click "Generate new token" and be sure to select the "notifications" scope, then click "Generate token".
 
+- **Environment variables**: the following environment variables are supported too: `GITHUB_NOTIFICATIONS_TOKEN`.
+
+
 ```js
 {
   "githubNotificationsBell.refreshInterval": 300, // Amount of seconds to wait before each refresh

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -11,7 +11,19 @@ import Utils from './utils';
 
 class Statusbar {
 
-  bell; config; oauthToken; all = 0;
+  bell; all = 0;
+
+  get config () {
+
+    return Config.get ();
+
+  }
+
+  get oauthToken () {
+
+    return this.config.oauthToken || process.env.GITHUB_NOTIFICATIONS_TOKEN;
+
+  }
 
   async init () {
 
@@ -27,23 +39,17 @@ class Statusbar {
 
   initBell () {
 
-    const config = Config.get (),
-      alignment = config.alignment === 'left' ? vscode.StatusBarAlignment.Left : vscode.StatusBarAlignment.Right;
-    this.oauthToken = config.oauthToken || process.env.GITHUB_NOTIFICATIONS_TOKEN;
+    const alignment = this.config.alignment === 'left' ? vscode.StatusBarAlignment.Left : vscode.StatusBarAlignment.Right;
 
     this.bell = vscode.window.createStatusBarItem ( alignment, -Infinity );
-    this.bell.text = `$(${config.icon})`;
+    this.bell.text = `$(${this.config.icon})`;
     this.bell.command = 'githubNotificationsBell.openInBrowser';
 
   }
 
   async update ( force? ) {
 
-    this.config = Config.get ();
-
-    if ( !this.oauthToken ) {
-      return vscode.window.showErrorMessage ( 'You need to provide an OAuth token via the "githubNotificationsBell.oauthToken" setting' );
-    }
+    if ( !this.oauthToken ) return vscode.window.showErrorMessage ( 'You need to provide an OAuth token via the "githubNotificationsBell.oauthToken" setting or "GITHUB_NOTIFICATIONS_TOKEN" environment variable' );
 
     await this.updateState ( force );
     this.updateText ();

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -11,7 +11,7 @@ import Utils from './utils';
 
 class Statusbar {
 
-  bell; config; all = 0;
+  bell; config; oauthToken; all = 0;
 
   async init () {
 
@@ -28,7 +28,8 @@ class Statusbar {
   initBell () {
 
     const config = Config.get (),
-          alignment = config.alignment === 'left' ? vscode.StatusBarAlignment.Left : vscode.StatusBarAlignment.Right;
+      alignment = config.alignment === 'left' ? vscode.StatusBarAlignment.Left : vscode.StatusBarAlignment.Right;
+    this.oauthToken = config.oauthToken || process.env.GITHUB_NOTIFICATIONS_TOKEN;
 
     this.bell = vscode.window.createStatusBarItem ( alignment, -Infinity );
     this.bell.text = `$(${config.icon})`;
@@ -40,7 +41,9 @@ class Statusbar {
 
     this.config = Config.get ();
 
-    if ( !this.config.oauthToken ) return vscode.window.showErrorMessage ( 'You need to provide an OAuth token via the "githubNotificationsBell.oauthToken" setting' );
+    if ( !this.oauthToken ) {
+      return vscode.window.showErrorMessage ( 'You need to provide an OAuth token via the "githubNotificationsBell.oauthToken" setting' );
+    }
 
     await this.updateState ( force );
     this.updateText ();
@@ -59,7 +62,7 @@ class Statusbar {
       try {
 
         const headers = {
-          Authorization: `token ${this.config.oauthToken}`,
+          Authorization: `token ${this.oauthToken}`,
           'User-Agent': 'vscode-github-notifications-bell'
         };
 


### PR DESCRIPTION
The README text and commit message have been taken directly from bump: https://github.com/fabiospampinato/bump/commit/d7c780cb6d6330e09ec48f61184a413999293bc0 :)

Closes #8 

@fabiospampinato what do you think about the error message:
> You need to provide an OAuth token via the "githubNotificationsBell.oauthToken" setting'

Should I also add the mention of the env var in there?