### PR TITLE
Add install package script

### DIFF
--- a/.vscode/install-package.js
+++ b/.vscode/install-package.js
@@ -1,0 +1,14 @@
+const cp = require('child_process');
+
+const PACKAGED_FILE = './' + process.env.npm_package_name + '-' + process.env.npm_package_version + '.vsix';
+
+console.log('');
+cp.exec('code --install-extension ' + PACKAGED_FILE, { cwd: process.cwd() }, (err, stdout, stderr) => {
+  if (err) {
+    console.log('ERROR:');
+    console.log(err);
+    process.exit(1);
+  } else {
+    console.log(stderr + stdout);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
   },
   "scripts": {
     "vscode:prepublish": "rm -rf out && webpack --mode production",
+    "package-and-install": "vsce package && node ./.vscode/install-package.js",
     "compile": "webpack --mode development",
     "compile:watch": "webpack --mode development --watch",
     "postinstall": "node ./node_modules/vscode/bin/install",


### PR DESCRIPTION
I've seen this in some other vscode extensions. Not sure if you'd be interested in having this and/or if you find it useful. I used this to debug adding GITHUB_NOTIFICATIONS_TOKEN env var. This "permanently" overwrites the installed extension from vscode marketplace.