### PR TITLE
Added support for baseUrls

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This extension requires you to provide an OAuth token, to create it go [here](ht
   "githubNotificationsBell.color": "", // Bell's color when there are some notifications
   "githubNotificationsBell.hideIfNone": true, // Hide the bell if there are no notifications
   "githubNotificationsBell.showNumberOfNotifications": true // Show the number of notifications alongside the bell icon
-  "githubNotificationsBell.baseUrl": "https://github.com" // The Github URL to query against. Github Enterprise may use a non-standard url
+  "githubNotificationsBell.domain": "github.com" // The Github domain to query against. Github Enterprise may use a different domain
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This extension requires you to provide an OAuth token, to create it go [here](ht
   "githubNotificationsBell.color": "", // Bell's color when there are some notifications
   "githubNotificationsBell.hideIfNone": true, // Hide the bell if there are no notifications
   "githubNotificationsBell.showNumberOfNotifications": true // Show the number of notifications alongside the bell icon
+  "githubNotificationsBell.baseUrl": "https://github.com" // The Github URL to query against. Github Enterprise may use a non-standard url
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -54,10 +54,10 @@
           "description": "Show the number of notifications alongside the bell icon",
           "default": true
         },
-        "githubNotificationsBell.baseUrl": {
+        "githubNotificationsBell.domain": {
           "type": "string",
-          "description": "The Github URL to query against. Github Enterprise may use a non-standard url",
-          "default": "https://github.com"
+          "description": "The Github domain to query against. Github Enterprise may use a different domain",
+          "default": "github.com"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "GitHub Notifications",
   "description": "A secure, customizable, statusbar icon that notifies you about notifications on GitHub.",
   "icon": "resources/logo-128x128.png",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "license": "MIT",
   "main": "out/extension.js",
   "publisher": "fabiospampinato",
@@ -53,6 +53,11 @@
           "type": "boolean",
           "description": "Show the number of notifications alongside the bell icon",
           "default": true
+        },
+        "githubNotificationsBell.baseUrl": {
+          "type": "string",
+          "description": "The Github URL to query against. Github Enterprise may use a non-standard url",
+          "default": "https://github.com"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "GitHub Notifications",
   "description": "A secure, customizable, statusbar icon that notifies you about notifications on GitHub.",
   "icon": "resources/logo-128x128.png",
-  "version": "2.2.1",
+  "version": "2.2.0",
   "license": "MIT",
   "main": "out/extension.js",
   "publisher": "fabiospampinato",

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -24,7 +24,7 @@ function openInBrowser () {
 
   const config = Config.get ();
 
-  const url = `${config.baseUrl}/notifications`;
+  const url = `https://${config.domain}/notifications`;
 
   vscode.commands.executeCommand ( 'vscode.open', vscode.Uri.parse ( url ) );
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -22,7 +22,9 @@ async function refresh ( showNotification = true ) {
 
 function openInBrowser () {
 
-  const url = 'https://github.com/notifications';
+  const config = Config.get ();
+
+  const url = `${config.baseUrl}/notifications`;
 
   vscode.commands.executeCommand ( 'vscode.open', vscode.Uri.parse ( url ) );
 

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -78,10 +78,10 @@ class Statusbar {
           'User-Agent': 'vscode-github-notifications-bell'
         };
 
-        const { baseUrl } = this.config;
+        const { domain } = this.config;
 
         const result = await Promise.all ([
-          pify ( request )({ url: `${baseUrl}/notifications`, headers })
+          pify ( request )({ url: `https://${domain}/notifications`, headers })
         ]);
 
         await Utils.state.update ( 'all', JSON.parse ( result[0].body ).length );

--- a/src/statusbar.ts
+++ b/src/statusbar.ts
@@ -78,8 +78,10 @@ class Statusbar {
           'User-Agent': 'vscode-github-notifications-bell'
         };
 
+        const { baseUrl } = this.config;
+
         const result = await Promise.all ([
-          pify ( request )({ url: 'https://api.github.com/notifications', headers })
+          pify ( request )({ url: `${baseUrl}/notifications`, headers })
         ]);
 
         await Utils.state.update ( 'all', JSON.parse ( result[0].body ).length );


### PR DESCRIPTION
The hosted enterprise version of GitHub may be at a different url to the public one. 

`https://github.ibm.com/notifications` vs `https://github.com/notifications`.

 I've added a custom  config variable (`githubNotificationsBell.baseUrl`) which sets url to query. 

The default value is the same as the current value now (https://github.com) meaning it does not introduce a breaking change.